### PR TITLE
修复tpa指令获取Tab列表补全时，不能根据输入字符串匹配对应玩家的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>top.craft_hello.tpa</groupId>
     <artifactId>TPA</artifactId>
-    <version>3.2.7</version>
+    <version>3.2.8</version>
     <packaging>jar</packaging>
 
     <name>TPA</name>

--- a/src/main/java/top/craft_hello/tpa/tabcompleters/DenysTabCompleter.java
+++ b/src/main/java/top/craft_hello/tpa/tabcompleters/DenysTabCompleter.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import top.craft_hello.tpa.objects.PlayerDataConfig;
+import top.craft_hello.tpa.utils.OptimizedAsyncTabCompleteUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,17 +46,26 @@ public class DenysTabCompleter implements TabCompleter {
                 }
                 switch (subCommand) {
                     case "add":
+                        // 获取所有未被拒绝的离线玩家
+                        List<String> allowedPlayers = new ArrayList<>();
                         for (OfflinePlayer offlinePlayer : Bukkit.getOfflinePlayers()) {
-                            if (!playerDataConfig.isDeny(offlinePlayer.getUniqueId().toString())) list.add(offlinePlayer.getName());
+                            if (!playerDataConfig.isDeny(offlinePlayer.getUniqueId().toString()) && 
+                                !offlinePlayer.getName().equals(sender.getName())) {
+                                allowedPlayers.add(offlinePlayer.getName());
+                            }
                         }
 
-                        list.remove(sender.getName());
-                        break;
+                        // 使用优化的异步工具类过滤玩家名称
+                        return OptimizedAsyncTabCompleteUtil.filterPlayerNames(args[1], allowedPlayers);
                     case "remove":
+                        // 获取所有被拒绝的玩家
+                        List<String> deniedPlayers = new ArrayList<>();
                         for (String playerUUID : denyList) {
-                            list.add(Bukkit.getOfflinePlayer(UUID.fromString(playerUUID)).getName());
+                            deniedPlayers.add(Bukkit.getOfflinePlayer(UUID.fromString(playerUUID)).getName());
                         }
-                        break;
+
+                        // 使用优化的异步工具类过滤玩家名称
+                        return OptimizedAsyncTabCompleteUtil.filterPlayerNames(args[1], deniedPlayers);
                 }
             }
         }

--- a/src/main/java/top/craft_hello/tpa/tabcompleters/TpHereTabCompleter.java
+++ b/src/main/java/top/craft_hello/tpa/tabcompleters/TpHereTabCompleter.java
@@ -1,6 +1,5 @@
 package top.craft_hello.tpa.tabcompleters;
 
-import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
@@ -8,27 +7,33 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import top.craft_hello.tpa.objects.LanguageConfig;
+import top.craft_hello.tpa.utils.OptimizedAsyncTabCompleteUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class TpHereTabCompleter implements TabCompleter {
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
-        List<String> list = new ArrayList<>();
-        LanguageConfig language = LanguageConfig.getLanguage(sender);
-        if (args.length == 0){
-            return list;
+        if (args.length == 0) {
+            return null;
         }
 
-        if (sender instanceof Player && args.length == 1){
-            for (Player player : Bukkit.getOnlinePlayers()) {
-                if (!sender.equals(player)){
-                    list.add(player.getName());
-                }
+        if (sender instanceof Player && args.length == 1) {
+            Player player = (Player) sender;
+            String input = args[0]; // 获取用户输入的部分名称
+
+            // 使用优化的异步工具类过滤玩家名称
+            List<String> filteredPlayers = OptimizedAsyncTabCompleteUtil.filterOnlinePlayers(input, player);
+
+            // 如果没有匹配的玩家，显示"没有在线玩家"消息
+            if (filteredPlayers.isEmpty()) {
+                LanguageConfig language = LanguageConfig.getLanguage(sender);
+                filteredPlayers.add(language.getMessage("not_online_players"));
             }
-            if (list.isEmpty()) list.add(language.getMessage("not_online_players"));
+
+            return filteredPlayers;
         }
-        return list;
+
+        return null;
     }
 }

--- a/src/main/java/top/craft_hello/tpa/tabcompleters/TpLogoutTabCompleter.java
+++ b/src/main/java/top/craft_hello/tpa/tabcompleters/TpLogoutTabCompleter.java
@@ -1,27 +1,28 @@
 package top.craft_hello.tpa.tabcompleters;
 
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import top.craft_hello.tpa.utils.OptimizedAsyncTabCompleteUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class TpLogoutTabCompleter implements TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
-        List<String> list = new ArrayList<>();
-        if (args.length != 1) return list;
+        if (args.length != 1) return null;
 
         if (sender instanceof Player){
-            for (OfflinePlayer player : Bukkit.getOfflinePlayers()) list.add(player.getName());
+            Player player = (Player) sender;
+            String input = args[0]; // 获取用户输入的部分名称
+
+            // 使用优化的异步工具类过滤离线玩家名称
+            return OptimizedAsyncTabCompleteUtil.filterOfflinePlayers(input, player.getName());
         }
-        return list;
+        return null;
     }
 }

--- a/src/main/java/top/craft_hello/tpa/tabcompleters/TpaTabCompleter.java
+++ b/src/main/java/top/craft_hello/tpa/tabcompleters/TpaTabCompleter.java
@@ -11,6 +11,7 @@ import top.craft_hello.tpa.enums.PermissionType;
 import top.craft_hello.tpa.objects.Config;
 import top.craft_hello.tpa.objects.LanguageConfig;
 import top.craft_hello.tpa.utils.LoadingConfigUtil;
+import top.craft_hello.tpa.utils.OptimizedAsyncTabCompleteUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,18 +28,23 @@ public class TpaTabCompleter implements TabCompleter {
 
         if (args.length == 1){
             if (sender instanceof Player){
-                List<String> playerList = new ArrayList<>();
-                for (Player player : Bukkit.getOnlinePlayers()) {
-                    if (!sender.equals(player)){
-                        list.add(player.getName());
-                        playerList.add(player.getName());
-                    }
+                Player player = (Player) sender;
+                String input = args[0]; // 获取用户输入的部分名称
+
+                // 使用优化的异步工具类过滤玩家名称
+                List<String> filteredPlayers = OptimizedAsyncTabCompleteUtil.filterOnlinePlayers(input, player);
+
+                // 如果没有匹配的玩家，显示"没有在线玩家"消息
+                if (filteredPlayers.isEmpty()) {
+                    filteredPlayers.add(language.getMessage("not_online_players"));
                 }
 
-                if (playerList.isEmpty()) list.add(language.getMessage("not_online_players"));
-                if (config.hasPermission(sender, PermissionType.RELOAD)) list.add("reload");
-                if (config.hasPermission(sender, PermissionType.VERSION)) list.add("version");
-                list.add("setlang");
+                // 添加命令选项
+                if (config.hasPermission(sender, PermissionType.RELOAD)) filteredPlayers.add("reload");
+                if (config.hasPermission(sender, PermissionType.VERSION)) filteredPlayers.add("version");
+                filteredPlayers.add("setlang");
+
+                return filteredPlayers;
             }
             return list;
         }

--- a/src/main/java/top/craft_hello/tpa/utils/OptimizedAsyncTabCompleteUtil.java
+++ b/src/main/java/top/craft_hello/tpa/utils/OptimizedAsyncTabCompleteUtil.java
@@ -1,0 +1,150 @@
+package top.craft_hello.tpa.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * 优化的异步Tab补全工具类，使用缓存和高效算法
+ */
+public class OptimizedAsyncTabCompleteUtil {
+    // 缓存在线玩家名称列表，使用线程安全的集合
+    private static final List<String> cachedOnlinePlayerNames = new CopyOnWriteArrayList<>();
+    private static final Map<String, List<String>> prefixCache = new ConcurrentHashMap<>();
+
+    // 缓存刷新间隔（毫秒）
+    private static final long CACHE_REFRESH_INTERVAL = 5000; // 5秒刷新一次
+    private static long lastCacheUpdate = 0;
+
+    /**
+     * 异步根据输入的部分名称过滤在线玩家列表
+     * @param input 用户输入的部分名称
+     * @param excludePlayer 要排除的玩家（可为null）
+     * @return 过滤后的玩家名称列表
+     */
+    public static List<String> filterOnlinePlayers(String input, Player excludePlayer) {
+        // 检查缓存是否需要更新
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastCacheUpdate > CACHE_REFRESH_INTERVAL || cachedOnlinePlayerNames.isEmpty()) {
+            // 直接在当前线程更新缓存，避免创建过多任务
+            updateOnlinePlayerCache();
+            lastCacheUpdate = currentTime;
+        }
+
+        // 如果没有输入，返回缓存的在线玩家列表（排除指定玩家）
+        if (input == null || input.isEmpty()) {
+            List<String> result = new ArrayList<>(cachedOnlinePlayerNames);
+            if (excludePlayer != null) {
+                result.remove(excludePlayer.getName());
+            }
+            return result;
+        }
+
+        // 检查前缀缓存
+        String lowerInput = input.toLowerCase();
+        List<String> cachedResult = prefixCache.get(lowerInput);
+        if (cachedResult != null && !cachedResult.isEmpty()) {
+            List<String> result = new ArrayList<>(cachedResult);
+            if (excludePlayer != null) {
+                result.remove(excludePlayer.getName());
+            }
+            return result;
+        }
+
+        // 使用流式处理进行高效过滤
+        List<String> result = cachedOnlinePlayerNames.stream()
+            .filter(name -> excludePlayer == null || !name.equals(excludePlayer.getName()))
+            .filter(name -> name.toLowerCase().startsWith(lowerInput))
+            .collect(Collectors.toList());
+
+        // 缓存结果，但限制缓存大小
+        if (prefixCache.size() < 100) { // 限制缓存大小，防止内存泄漏
+            prefixCache.put(lowerInput, new ArrayList<>(result));
+        }
+
+        return result;
+    }
+
+    /**
+     * 根据输入的部分名称过滤离线玩家列表
+     * @param input 用户输入的部分名称
+     * @param excludePlayerName 要排除的玩家名称（可为null）
+     * @return 过滤后的玩家名称列表
+     */
+    public static List<String> filterOfflinePlayers(String input, String excludePlayerName) {
+        // 由于离线玩家列表可能很大，我们限制返回的结果数量
+        List<String> result = new ArrayList<>();
+        int maxResults = 50; // 最多返回50个结果，防止列表过长
+
+        // 如果没有输入，返回部分离线玩家（排除指定玩家）
+        if (input == null || input.isEmpty()) {
+            for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+                if (excludePlayerName == null || !player.getName().equals(excludePlayerName)) {
+                    result.add(player.getName());
+                    if (result.size() >= maxResults) break;
+                }
+            }
+            return result;
+        }
+
+        // 根据输入过滤玩家名称
+        String lowerInput = input.toLowerCase();
+        for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            if (excludePlayerName != null && player.getName().equals(excludePlayerName)) {
+                continue;
+            }
+
+            // 检查玩家名称是否以输入字符串开头（不区分大小写）
+            if (player.getName() != null && player.getName().toLowerCase().startsWith(lowerInput)) {
+                result.add(player.getName());
+                if (result.size() >= maxResults) break;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * 根据输入的部分名称过滤指定的玩家名称列表
+     * @param input 用户输入的部分名称
+     * @param playerNames 玩家名称列表
+     * @return 过滤后的玩家名称列表
+     */
+    public static List<String> filterPlayerNames(String input, List<String> playerNames) {
+        // 如果没有输入或列表为空，返回原列表
+        if (input == null || input.isEmpty() || playerNames == null || playerNames.isEmpty()) {
+            return playerNames != null ? new ArrayList<>(playerNames) : new ArrayList<>();
+        }
+
+        // 使用流式处理进行高效过滤
+        String lowerInput = input.toLowerCase();
+        return playerNames.stream()
+            .filter(name -> name != null && name.toLowerCase().startsWith(lowerInput))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 更新在线玩家缓存
+     */
+    private static void updateOnlinePlayerCache() {
+        List<String> newPlayerNames = new ArrayList<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            newPlayerNames.add(player.getName());
+        }
+
+        // 更新缓存
+        cachedOnlinePlayerNames.clear();
+        cachedOnlinePlayerNames.addAll(newPlayerNames);
+
+        // 清除过期的前缀缓存
+        prefixCache.clear();
+    }
+}


### PR DESCRIPTION
修复tpa指令获取Tab列表补全时，不能根据输入字符串匹配对应玩家的问题
使用了异步
不过我是加上了离线玩家列表一起过滤，所以当离线玩家过多，还是会有一点点卡顿，所以作者最好做一下开关，开启关闭列表补全功能