### PR TITLE
修复禁用命令时 debug 输出异常栈

### DIFF
--- a/src/main/java/top/craft_hello/tpa/utils/ErrorCheckUtil.java
+++ b/src/main/java/top/craft_hello/tpa/utils/ErrorCheckUtil.java
@@ -4,6 +4,7 @@ import cn.handyplus.lib.adapter.PlayerSchedulerUtil;
 import org.bukkit.*;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import top.craft_hello.tpa.abstracts.ErrorException;
 import top.craft_hello.tpa.abstracts.Request;
 import top.craft_hello.tpa.enums.CommandType;
 import top.craft_hello.tpa.enums.PermissionType;
@@ -306,7 +307,7 @@ public class ErrorCheckUtil{
                     throw new ErrorRuntimeException(sender, "在 utils.ErrorCheckUtil 46 行，请联系开发者（https://github.com/WarSkyGod/TPA/issues）");
             }
         } catch (Exception exception){
-            if (config.isDebug()) exception.printStackTrace();
+            if (config.isDebug() && !(exception instanceof ErrorException)) exception.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
因为bukkit默认plugin注册了的命令，如果需要取消注册需要单独的unregistered，再次启用又需要注册，考虑到安全问题，故在禁用的命令执行时不会像控制台来显示报错问题，就是最小的修复方法
我使用了Claude来快速定位和修复问题<3